### PR TITLE
rename SlurmJobTask -> SlurmTask and use Config for shared configuration

### DIFF
--- a/luigi/contrib/slurm.py
+++ b/luigi/contrib/slurm.py
@@ -89,29 +89,34 @@ as shown below.
 # - Runner function loads the class from pickle
 # - Runner function hits the work button on it
 
+import itertools
+import luigi
 import os
-import subprocess
-import time
-import sys
+import pprint
 import logging
-import random
 import shutil
+import subprocess
+import sys
+import time
+import random
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
-import luigi
-
 from luigi.contrib import slurm_runner
 
-import itertools
-
 POLL_TIME = 15  # decided to hard-code rather than configure here
+MEM_RETRY_MAX_RETRIES = 10 # some hard limit to the maximum number of memory-related error retries
+MEM_RETRY_MAX_MEM = 128000 # hard memory limit per task on retry
 
 class slurm(luigi.Config):
     ntasks = luigi.IntParameter(default=1, significant=False)
     mem = luigi.IntParameter(default=4000, significant=False)
+    mem_retries = luigi.IntParameter(default=3, significant=False,
+        description="retries n times, doubling the memory each run if a task "
+        "fails on an out of memory error")
     gres = luigi.Parameter(default='', significant=False)
     partition = luigi.Parameter(default='', significant=False)
     time = luigi.Parameter(default='', significant=False)
@@ -259,13 +264,25 @@ class SlurmTask(luigi.Task):
             # default to the task family
             self.job_name = self.task_family
 
+        if not hasattr(self, 'mem') or self.mem is None:
+            self.mem = self.slurm_config.mem
+
+        if not hasattr(self, 'mem_retries') or self.mem_retries is None:
+            self.mem_retries = self.slurm_config.mem_retries
+
+        if not hasattr(self, '_mem_retry') or self._mem_retry is None:
+            self._mem_retry = 0
+
+
+    def __str__(self):
+        return '\n'.join([
+            pprint.pformat(vars(self.slurm_config), indent=2),
+            pprint.pformat(vars(self), indent=2)
+        ])
+
     @property
     def ntasks(self):
         return self.slurm_config.ntasks
-
-    @property
-    def mem(self):
-        return self.slurm_config.mem
 
     @property
     def gres(self):
@@ -355,7 +372,22 @@ class SlurmTask(luigi.Task):
             self.work()
         else:
             self._init_local()
-            self._run_job()
+            # retry on memory errors only, avoiding a while(1){} loop in favor of a hard limit
+            for i in range(0, MEM_RETRY_MAX_RETRIES):
+                try:
+                    self._run_job()
+                except OutOfMemoryError as e:
+                    # give up after configured number of retries
+                    if self._mem_retry > self.mem_retries:
+                        raise e
+                    # double memory allocation, up to some hard limit
+                    self.mem = self.mem * 2
+                    if self.mem > MEM_RETRY_MAX_MEM:
+                        raise e
+                    # bump the retry count
+                    self._mem_retry += 1
+                # done running the job
+                break
             # The procedure:
             # - Pickle the run method
             # - Construct a sbatch argument that runs a generic runner function with the path to the run method
@@ -401,8 +433,7 @@ class SlurmTask(luigi.Task):
         self.job_id = output.decode().strip()
         logger.debug("Submitted job to slurm with job id: {}".format(self.job_id))
 
-        successful = self._track_job()
-        job_output = '\n'.join(self._fetch_task_failures()) + '\n'.join(self._fetch_task_out())
+        successful, stderr, stdout, elapsed = self._track_job()
 
         # Now delete the temporaries, if they're there.
         if not self.dont_remove_tmp_dir:
@@ -412,7 +443,7 @@ class SlurmTask(luigi.Task):
 
         # stop here if the job was not successful
         if not successful:
-            raise RuntimeError('Slurm job has FAILED:\n' + job_output)
+            raise SlurmError('Slurm job has FAILED:', stdout, stderr, elapsed)
 
     def _track_job(self):
         successful = False
@@ -424,15 +455,16 @@ class SlurmTask(luigi.Task):
             # See what the job's up to
             # ASSUMPTION
             job_status = _parse_job_state(self.job_id)
+            elapsed = float(time.time() - start)
             if job_status == 'RUNNING' or job_status == 'COMPLETING':
-                logger.info('Job is running ({:0.1f} seconds elapsed)...'.format(float(time.time() - start)))
+                logger.info('Job is running ({:0.1f} seconds elapsed)...'.format(elapsed))
             elif job_status == 'PENDING':
-                logger.info('Job is pending ({:0.1f} seconds elapsed)...'.format(float(time.time() - start)))
+                logger.info('Job is pending ({:0.1f} seconds elapsed)...'.format(elapsed))
             elif 'FAILED' in job_status:
-                logger.error('Job has FAILED:\n' + '\n'.join(self._fetch_task_failures()) + '\n'.join(self._fetch_task_out()))
+                logger.error('Job has FAILED')
                 break
             elif 'CANCELLED' in job_status:
-                logger.error('Job has been CANCELLED:\n' + '\n'.join(self._fetch_task_failures()) + '\n'.join(self._fetch_task_out()))
+                logger.error('Job has been CANCELLED')
                 break
             elif job_status == 'COMPLETED' or job_status == 'u':
                 # Then the job could either be failed or done.
@@ -444,11 +476,25 @@ class SlurmTask(luigi.Task):
                     for error in errors:
                         logger.error(error)
                 break
+            elif job_status == 'OUT_OF_MEMORY':
+                logger.error('Job ran OUT_OF_MEMORY')
+                raise OutOfMemoryError(
+                    "job status isn't one of ['RUNNING', 'PENDING', 'COMPLETED', 'FAILED', 'CANCELLED', 'u']: {}".format(job_status),
+                    '\n'.join(self._fetch_task_out()),
+                    '\n'.join(self._fetch_task_failures())
+                )
+                break
             else:
                 logger.info('Job status is UNKNOWN!')
                 logger.info('Status is : {}'.format(job_status))
-                raise Exception("job status isn't one of ['RUNNING', 'PENDING', 'COMPLETED', 'FAILED', 'CANCELLED', 'u']: %s" % job_status)
-        return successful
+                raise SlurmError(
+                    "job status isn't one of ['RUNNING', 'PENDING', 'COMPLETED', 'FAILED', 'CANCELLED', 'u']: {}".format(job_status),
+                    '\n'.join(self._fetch_task_out()),
+                    '\n'.join(self._fetch_task_failures())
+                )
+        stdout = '\n'.join(self._fetch_task_out())
+        stderr = '\n'.join(self._fetch_task_failures())
+        return (successful, stderr, stdout, elapsed)
 
 
 class LocalSlurmTask(SlurmTask):
@@ -461,3 +507,22 @@ class LocalSlurmTask(SlurmTask):
 
     def run(self):
         self.work()
+
+
+class SlurmError(RuntimeError):
+    def __init__(self, message, out=None, err=None, elapsed=None):
+        super(SlurmError, self).__init__(message, out, err)
+        self.message = message
+        self.out = out
+        self.err = err
+        self.elapsed = elapsed
+
+    def __str__(self):
+        info = "Task Time Elapsed {}:\n{}".format(self.elapsed, self.message)
+        if self.out:
+            info += "\nSTDOUT: " + str(self.out)
+        if self.err:
+            info += "\nSTDERR: " + str(self.err)
+        return info
+
+class OutOfMemoryError(SlurmError): pass

--- a/luigi/contrib/slurm.py
+++ b/luigi/contrib/slurm.py
@@ -110,7 +110,7 @@ import itertools
 POLL_TIME = 15  # decided to hard-code rather than configure here
 
 class slurm(luigi.Config):
-    ntasks = luigi.IntParameter(default=2, significant=False)
+    ntasks = luigi.IntParameter(default=1, significant=False)
     mem = luigi.IntParameter(default=4000, significant=False)
     gres = luigi.Parameter(default='', significant=False)
     partition = luigi.Parameter(default='', significant=False)

--- a/luigi/contrib/slurm_runner.py
+++ b/luigi/contrib/slurm_runner.py
@@ -35,6 +35,7 @@ the job has left the queue, delete the temporary folder, and
 return from SlurmJobTask.run()
 """
 
+import argparse
 import os
 import sys
 try:
@@ -42,56 +43,25 @@ try:
 except ImportError:
     import pickle
 import logging
-import tarfile
-
-
-def _do_work_on_compute_node(work_dir, tarball=True):
-
-    if tarball:
-        # Extract the necessary dependencies
-        # This can create a lot of I/O overhead when running many SlurmJobTask,
-        # so is optional if the luigi project is accessible from the cluster node
-        _extract_packages_archive(work_dir)
-
-    # Open up the pickle file with the work to be done
-    os.chdir(work_dir)
-    with open("job-instance.pickle", "rb") as f:
-        job = pickle.load(f)
-
-    # Do the work contained
-    job.work()
-
-
-def _extract_packages_archive(work_dir):
-    package_file = os.path.join(work_dir, "packages.tar")
-    if not os.path.exists(package_file):
-        return
-
-    curdir = os.path.abspath(os.curdir)
-
-    os.chdir(work_dir)
-    tar = tarfile.open(package_file)
-    for tarinfo in tar:
-        tar.extract(tarinfo)
-    tar.close()
-    if '' not in sys.path:
-        sys.path.insert(0, '')
-
-    os.chdir(curdir)
 
 
 def main(args=sys.argv):
     """Run the work() method from the class instance in the file "job-instance.pickle".
     """
     try:
-        tarball = "--no-tarball" not in args
+        parser = argparse.ArgumentParser(description='slurm runner')
         # Set up logging.
         logging.basicConfig(level=logging.WARN)
-        work_dir = args[1]
-        assert os.path.exists(work_dir), "First argument to slurm_runner.py must be a directory that exists"
-        project_dir = args[2]
-        sys.path.append(project_dir)
-        _do_work_on_compute_node(work_dir, tarball)
+        parser.add_argument('--tmp-dir', dest='tmp_dir', type=str)
+        args = parser.parse_args()
+
+        sys.path.append(os.getcwd())
+        job = None
+        with open(os.path.join(args.tmp_dir, 'job.pickle'), 'rb') as f:
+            job = pickle.load(f)
+        # Do the work contained
+        job.work()
+
     except Exception as e:
         # Dump encoded data that we will try to fetch using mechanize
         print(e)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -276,7 +276,7 @@ class Task(object):
                 except KeyboardInterrupt:
                     return
                 except BaseException:
-                    logger.exception("Error in event callback for %r", event)
+                    logger.exception("Error in event callback (%s) for %r", callback, event)
 
     @property
     def task_module(self):


### PR DESCRIPTION
Thanks for the SLURM runner @jcftang. I've just started using this and moved a couple things around.

This will probably need a few more changes, but wanted to see what you think while it's a WIP

With the config, we can now define shared properties in `luigi.cfg`

e.g.

```
[slurm]
ntasks=1
mem=1000
mem-per-cpu=2000
#gres=
#partition=
#time=
shared-tmp-dir=/my/tmp/dir
#job_name_format =
#run_locally = True
#poll_time =
#dont_remove_tmp_dir =
#no_tarball =
```