### PR TITLE
Simplification and minor tweaks

### DIFF
--- a/luigi/contrib/remote_runner.py
+++ b/luigi/contrib/remote_runner.py
@@ -85,11 +85,17 @@ def main(args=sys.argv):
     try:
         tarball = "--no-tarball" not in args
         work_dir = args[1]
-        logging.basicConfig(
-            filename=os.path.join(work_dir, "runner.log"),
-            level=logging.INFO,
-            format="%(asctime)s %(levelname)-8s %(message)s",
-        )
+
+        try:
+            logger_file = args[3]
+            logging.basicConfig(
+                filename=logger_file,
+                level=logging.INFO,
+                format="%(asctime)s %(levelname)-8s %(message)s",
+            )
+        except:
+            logging.basicConfig(level=logging.WARN)
+
         assert os.path.exists(
             work_dir
         ), "First argument to slurm_runner.py must be a directory that exists"

--- a/luigi/contrib/remote_runner.py
+++ b/luigi/contrib/remote_runner.py
@@ -93,7 +93,7 @@ def main(args=sys.argv):
                 level=logging.INFO,
                 format="%(asctime)s %(levelname)-8s %(message)s",
             )
-        except:
+        except IndexError:
             logging.basicConfig(level=logging.WARN)
 
         assert os.path.exists(

--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -102,7 +102,7 @@ except ImportError:
 
 import luigi
 from luigi.contrib.hadoop import create_packages_archive
-from luigi.contrib import sge_runner
+from luigi.contrib import remote_runner
 
 logger = logging.getLogger('luigi-interface')
 logger.propagate = 0
@@ -284,8 +284,8 @@ class SGEJobTask(luigi.Task):
 
     def _run_job(self):
 
-        # Build a qsub argument that will run sge_runner.py on the directory we've specified
-        runner_path = sge_runner.__file__
+        # Build a qsub argument that will run remote_runner.py on the directory we've specified
+        runner_path = remote_runner.__file__
         if runner_path.endswith("pyc"):
             runner_path = runner_path[:-3] + "py"
         job_str = 'python {0} "{1}" "{2}"'.format(

--- a/luigi/contrib/slurm.py
+++ b/luigi/contrib/slurm.py
@@ -69,7 +69,7 @@ except ImportError:
 import luigi
 from luigi.contrib.hadoop import create_packages_archive
 
-from cloacina.luigi.framework import sge_runner
+from cloacina.luigi.framework import remote_runner
 
 logger = logging.getLogger('luigi-interface')
 
@@ -321,8 +321,8 @@ class SlurmTask(luigi.Task):
                 pickle.dump(self, open(self.job_file, "wb"))
 
     def _run_job(self):
-        # Build a sbatch argument that will run sge_runner.py on the directory we've specified
-        runner_path = sge_runner.__file__
+        # Build a sbatch argument that will run remote_runner.py on the directory we've specified
+        runner_path = remote_runner.__file__
         if runner_path.endswith("pyc"):
             runner_path = runner_path[:-1]
 

--- a/luigi/contrib/slurm.py
+++ b/luigi/contrib/slurm.py
@@ -326,9 +326,9 @@ class SlurmTask(luigi.Task):
         if runner_path.endswith("pyc"):
             runner_path = runner_path[:-1]
 
-        job_cmd = 'python {0} "{1}" "{2}"'.format(
-            runner_path, self.tmp_dir, os.getcwd()
-        )  # enclose tmp_dir in quotes to protect from special escape chars
+        job_cmd = 'python {0} "{1}" "{2}" "{3}"'.format(
+            runner_path, self.tmp_dir, os.getcwd(), os.path.join(self.tmp_dir, "runner.log")
+        )  
         if not self.tarball:
             job_cmd += ' "--no-tarball"'
 

--- a/luigi/contrib/slurm.py
+++ b/luigi/contrib/slurm.py
@@ -116,7 +116,7 @@ def _parse_job_state(job_id):
         job_s = job.split("=")
         try:
             job_map[job_s[0]] = job_s[1]
-        except:
+        except Exception as e:
             logger.error("No value found for {}".format(job_s[0]))
 
     return job_map.get('JobState', 'u')
@@ -201,7 +201,7 @@ class SlurmTask(luigi.Task):
         # Call input() here so upstream Task objects are pickled (exposed via input() method below).
         try:
             upstream = luigi.Task.input(self)
-        except:
+        except Exception as e:
             upstream = None
 
         self.my_upstream = upstream
@@ -327,8 +327,10 @@ class SlurmTask(luigi.Task):
             runner_path = runner_path[:-1]
 
         job_cmd = 'python {0} "{1}" "{2}" "{3}"'.format(
-            runner_path, self.tmp_dir, os.getcwd(), os.path.join(self.tmp_dir, "runner.log")
-        )  
+                runner_path, 
+                self.tmp_dir, 
+                os.getcwd(), 
+                os.path.join(self.tmp_dir, "runner.log"))  
         if not self.tarball:
             job_cmd += ' "--no-tarball"'
 


### PR DESCRIPTION
- Changed the way sbatch parameters are passed to the SlurmJobTask. Instead of us trying to replicate the whole sbatch API as Luigi parameters (or a limited part of it), the user now just passes just one Luigi parameter with a list of sbatch parameters and it’s up to them to ensure that it results in a valid sbatch command. This simplifies things immensely and allows for more flexibility.

- Clarified the "no-tarball" option (which will only work in its current state with the Luigi module and standard library) and defaulted it to not be used. 

- Changed how logger messages are passed from the remote job to the parent.

- SlurmTask now automatically traverses upstream tasks so they get pickled out and can be referred to in the remote job.

- Got rid of automatic retrying for jobs which run out of memory, which I think is a bad idea.

- Misc formatting/structure changes. 
